### PR TITLE
rotate-screen: recognize Debian 13 for the weston transform update

### DIFF
--- a/bin/prod/rotate-screen
+++ b/bin/prod/rotate-screen
@@ -60,7 +60,7 @@ update_weston(){
         echo "Misssig file: ${CONFIG_FILE}"
     else
         case "$RELEASE" in
-            11 | 12)
+            11 | 12 | 13)
                 sed -i "s/transform.*/transform=${ROT_WESTON_11}/" "${CONFIG_FILE}"
                 ;;
             10)


### PR DESCRIPTION
## Problem

`rotate-screen`'s `update_weston()` only matched Debian release `10`, `11`, or `12` before writing `transform=` into the target's `weston.ini`. Rebuild moved to Debian 13 (trixie) this cycle, so this fell into the `*)` branch and silently did nothing - `EXTERNAL_SCREEN_ROTATION` was being saved to `/etc/rebuild-settings` correctly, but never actually applied to the touchscreen.

## Fix

One-line case pattern change: `11 | 12)` → `11 | 12 | 13)`.

## Test plan

- [x] Confirmed `/etc/debian_version` is `13.6` on a live board
- [x] Applied the fixed logic directly against the live board's `weston.ini` for `EXTERNAL_SCREEN_ROTATION=270` (the value already saved in `/etc/rebuild-settings`) - correctly set `transform=rotate-90`
- [x] Restarted `weston` + `toggle`, both came back `active`
- [x] Visually confirmed on the physical screen: Toggle UI now displays in the correct orientation

🤖 Generated with [Claude Code](https://claude.com/claude-code)