### PR TITLE
Add a PLYMOUTH place to rotate-screen for the DRM panel orientation

### DIFF
--- a/bin/prod/rotate-screen
+++ b/bin/prod/rotate-screen
@@ -7,7 +7,7 @@ PLACE=$2
 ROTATIONS=(0 90 180 270)
 
 # Valid places to update
-PLACES=(FBCON XORG CMDLINE WESTON)
+PLACES=(FBCON XORG CMDLINE WESTON PLYMOUTH)
 
 EMMC=/dev/mmcblk2
 
@@ -92,6 +92,29 @@ update_fbcon() {
     echo $ROT_FBCON > /sys/devices/virtual/graphics/fbcon/rotate
 }
 
+# Plymouth's DRM renderer ignores fbcon=rotate: entirely (that only
+# affects the legacy fbcon text console) - it reads the kernel's DRM
+# panel orientation instead, set via video=<connector>:panel_orientation=<value>
+# on the kernel command line.
+update_plymouth(){
+    mkdir -p /mnt/emmc
+    umount -q /mnt/emmc/ || true
+    mount "${EMMC}p1" /mnt/emmc
+
+    CONFIG_FILE="/mnt/emmc/armbianEnv.txt"
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "Misssig file: ${CONFIG_FILE}"
+    else
+        if [[ $(grep 'panel_orientation=' "$CONFIG_FILE") ]]; then
+            sed -i -E "s/panel_orientation=[a-z_]+/panel_orientation=${ROT_PLYMOUTH}/" "$CONFIG_FILE"
+        else
+            sed -i "/extraargs=/ s/\$/ video=HDMI-A-1:panel_orientation=${ROT_PLYMOUTH}/" "$CONFIG_FILE"
+        fi
+        cat "$CONFIG_FILE"
+    fi
+    umount /mnt/emmc
+}
+
 if [ "$ROTATION" == "" ]; then
     usage 
     exit 1
@@ -106,7 +129,8 @@ case "${ROTATION}" in
     0)
         ROT_XORG="normal"
         ROT_FBCON="0"
-        ROT_PLYMOUTH=""
+        # Confirmed empirically on real hardware.
+        ROT_PLYMOUTH="normal"
         ROT_WESTON_10="0"
         ROT_WESTON_11="normal"
         ROT_MATRIX="1 0 0 0 1 0 0 0 1"
@@ -114,7 +138,10 @@ case "${ROTATION}" in
     90)
         ROT_XORG="right"
         ROT_FBCON="1"
-        ROT_PLYMOUTH=""
+        # Not empirically confirmed - inferred by elimination
+        # from the four DRM panel-orientation values, given 0 and
+        # 270 are confirmed. Verify on hardware before trusting.
+        ROT_PLYMOUTH="right_side_up"
         ROT_WESTON_10="270"
         ROT_WESTON_11="rotate-270"
         ROT_MATRIX="0 1 0 -1 0 1 0 0 1"
@@ -122,7 +149,9 @@ case "${ROTATION}" in
     180)
         ROT_XORG="inverted"
         ROT_FBCON="2"
-        ROT_PLYMOUTH=""
+        # Not empirically confirmed - inferred by elimination, see
+        # the note on the 90 case above.
+        ROT_PLYMOUTH="upside_down"
         ROT_WESTON_10="180"
         ROT_WESTON_11="rotate-180"
         ROT_MATRIX="-1 0 1 0 -1 1 0 0 1"
@@ -130,7 +159,8 @@ case "${ROTATION}" in
     270)
         ROT_XORG="left"
         ROT_FBCON="3"
-        ROT_PLYMOUTH=""
+        # Confirmed empirically on real hardware.
+        ROT_PLYMOUTH="left_side_up"
         ROT_WESTON_10="90"
         ROT_WESTON_11="rotate-90"
         ROT_MATRIX="0 -1 1 1 0 0 0 0 1"
@@ -155,6 +185,9 @@ case "${PLACE}" in
         ;;
     WESTON)
         update_weston
+        ;;
+    PLYMOUTH)
+        update_plymouth
         ;;
     *)
         echo "$PLACE not in " "${PLACES[@]}"

--- a/reflash/server.go
+++ b/reflash/server.go
@@ -1017,6 +1017,10 @@ func runInstallFinishedCommands(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		sendResponse(w, err)
 	}
+	err = cmdRotateScreen(options.ScreenRotation, "PLYMOUTH")
+	if err != nil {
+		sendResponse(w, err)
+	}
 
 	settings := "# Settings from Reflash\n" +
 		"SSH_ENABLED_ON_BOOT=" + strconv.FormatBool(options.EnableSsh) + "\n" +


### PR DESCRIPTION
## Problem

Companion fix to Rebuild#70 (installing Plymouth for a real boot splash). The splash showed up, but wasn't rotated - Plymouth's DRM renderer ignores `fbcon=rotate:` entirely, since that only affects the legacy fbcon text console.

## Fix

Plymouth reads the kernel's DRM panel orientation instead, set via `video=<connector>:panel_orientation=<value>` on the kernel command line - a mechanism none of the other four `rotate-screen` places (`FBCON`/`XORG`/`CMDLINE`/`WESTON`) touch.

- Fills in the `ROT_PLYMOUTH` variable that was already sitting there unused in each rotation case.
- Adds `update_plymouth()`, mirroring `update_cmdline()`'s mount/sed/umount pattern against `armbianEnv.txt`.
- Wires `PLYMOUTH` into the `PLACES` array and dispatch.
- `server.go` now calls `cmdRotateScreen(..., "PLYMOUTH")` alongside the existing `CMDLINE`/`XORG`/`WESTON` calls in `runInstallFinishedCommands`.

**Caveat**: only `0`->`normal` and `270`->`left_side_up` are empirically confirmed on real hardware. `90`->`right_side_up` and `180`->`upside_down` are inferred by elimination from the four DRM panel-orientation values and flagged as such in comments - worth validating on hardware before fully trusting those two.

## Test plan

- [x] Ran the actual updated script live on real hardware (`rotate-screen 270 PLYMOUTH`), confirmed it correctly writes/updates `video=HDMI-A-1:panel_orientation=left_side_up`
- [x] Confirmed idempotent - re-running with a different rotation updates the value in place rather than duplicating the parameter
- [x] `go build` passes with the `server.go` change
- [x] Confirmed end-to-end on a real reboot: splash now shows in the correct orientation

Note: `go test ./...` currently fails on a pre-existing, unrelated crash in `TestHandleSerialCommand` - confirmed present on clean `main` before this change, not something introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)