### PR TITLE
wifi-connect: bump DHCP wait from 10s to 30s

### DIFF
--- a/bin/prod/wifi-connect
+++ b/bin/prod/wifi-connect
@@ -72,7 +72,7 @@ done
 
 # 5. Wait and verify IP address
 info "Waiting for DHCP..."
-MAX_RETRIES=10
+MAX_RETRIES=30
 COUNT=0
 while [ $COUNT -lt $MAX_RETRIES ]; do
     IP=$(ip addr show "$INTERFACE" | grep "inet " | awk '{print $2}')


### PR DESCRIPTION
10s to get an IP after the connection is accepted is tight, especially on links that have already shown other timing sensitivity this session.

Same reasoning as the Rebuild-side `CLIENT_TIMEOUT` bump (30s -> 60s): worst case this just adds a few seconds to a failed attempt, but a too-short wait can report a spurious failure on a connection that would have come up fine given a bit more time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)