### PR TITLE
Fix lastLine() killing the whole process via log.Fatal

### DIFF
--- a/reflash/server.go
+++ b/reflash/server.go
@@ -987,7 +987,12 @@ func parseXzUncompressedSize(out string) int {
 func lastLine(file string) string {
 	out, err := exec.Command("tail", "-n1", file).Output()
 	if err != nil {
-		log.Fatal(err)
+		// Expected before the progress file exists yet (e.g. right at
+		// the start of a flash, or in tests) - the caller already
+		// falls back to 0 on a non-numeric result. log.Fatal here
+		// used to kill the whole process on this, not just this one
+		// read.
+		return ""
 	}
 	return strings.TrimSpace(string(out[:]))
 }


### PR DESCRIPTION
## Problem

`lastLine()` (used to read the flash-progress file) calls `log.Fatal(err)` if `tail -n1` fails - which happens whenever the progress file doesn't exist yet (right at the start of a flash, or when driving `handleSerialCommand` directly, as in tests). `log.Fatal` calls `os.Exit(1)`, taking down the *entire server process* on what's actually an expected, transient condition.

Found this while running `go test ./...` for an unrelated change - the whole suite was silently dying partway through `TestHandleSerialCommand`, since the `STATUS` subtest exercises this exact path without the progress file existing yet. No test after it in the package ever actually ran, and the failure showed only as an opaque `exit status 1` with no `--- FAIL` trace, making it non-obvious.

## Fix

Return `""` instead of crashing. The only caller (`refreshProgress`) already handles a non-numeric/empty result by falling back to `0` via `strconv.Atoi`'s error case - so this is a correct, already-expected fallback path, not a new one.

## Test plan

- [x] `go build` passes
- [x] `go test ./...` now runs to completion and passes (previously died partway through with no clear indication why)

🤖 Generated with [Claude Code](https://claude.com/claude-code)