### PR TITLE
Show the Reflash version on the embedded screen

### DIFF
--- a/reflash/screen.go
+++ b/reflash/screen.go
@@ -83,7 +83,7 @@ func ScreenInit() {
 
 	img = image.NewRGBA(image.Rect(0, 0, fb_min, fb_min))
 	ips := make([]string, 0)
-	Draw(0, "IDLE", 0, ips)
+	Draw(0, "IDLE", 0, ips, "")
 }
 
 func ScreenClose() {
@@ -92,7 +92,7 @@ func ScreenClose() {
 }
 
 // TODO: This is horrobly inefficient and should be optimized.
-func Draw(progress float32, state string, rot int, ips []string) {
+func Draw(progress float32, state string, rot int, ips []string, version string) {
 	// No framebuffer mapped → ScreenInit either failed (headless) or was
 	// never called (tests). Skip rendering entirely; updateDisplay still
 	// keeps its bookkeeping in sync.
@@ -115,6 +115,12 @@ func Draw(progress float32, state string, rot int, ips []string) {
 		drawText(img, "REFLASH", 50, (fb_min/2)+55)
 		for i, s := range ips {
 			drawText(img, s, 20, (fb_min/2)+125+(20*i))
+		}
+		// The screen is sometimes the only information available (e.g. no
+		// network reachable yet) - show the running version so it's visible
+		// without needing the web UI.
+		if version != "" {
+			drawText(img, version, 16, (fb_min/2)+125+(20*len(ips))+20)
 		}
 	} else {
 		if fb_min > 700 {

--- a/reflash/server.go
+++ b/reflash/server.go
@@ -149,6 +149,7 @@ var images_folder string
 var options_file string
 var log_file string
 var http_port string
+var reflashVersion string
 
 var last_size_check time.Time
 var bytes_last int
@@ -201,6 +202,8 @@ func ServerInit() {
 		BytesTotal: 1,
 	}
 
+	reflashVersion = runCommandReturnString("get-reflash-version")
+
 	logInfo("-- Server started at " + time.Now().Format("15:04:05") + " --")
 	expandUsb()
 	mountUsb(MODE_RO)
@@ -220,10 +223,8 @@ func ServerInit() {
 		updateDisplay()
 	}()
 
-	version := runCommandReturnString("get-reflash-version")
-
 	fs := http.FileServer(http.Dir(static_dir))
-	fmt.Println("Starting Reflash go server " + version + " env '" + env + "'")
+	fmt.Println("Starting Reflash go server " + reflashVersion + " env '" + env + "'")
 	http.Handle("/", fs)
 	http.HandleFunc("/api/get_info", getInfo)
 	http.HandleFunc("/api/stream_log", streamLog)
@@ -471,7 +472,7 @@ func updateDisplay() {
 	}
 	state.Lock()
 	if oldState.State != state.State || oldState.Progress != state.Progress || oldRotation != options.ScreenRotation || !slices.Equal(oldState.IPs, state.IPs) {
-		Draw(float32(state.Progress)/100, state.State, options.ScreenRotation, state.IPs)
+		Draw(float32(state.Progress)/100, state.State, options.ScreenRotation, state.IPs, reflashVersion)
 		oldState.State = state.State
 		oldState.Progress = state.Progress
 		oldRotation = options.ScreenRotation


### PR DESCRIPTION
## Summary
- The idle screen (logo + IP addresses) now also shows the running Reflash version below the IPs. The screen is sometimes the only information available to the user (e.g. no network yet), so it's worth surfacing without needing the web UI.
- `reflashVersion` is fetched once at startup (`ServerInit`) and reused for the screen draw, rather than re-fetching on every draw.

## Testing
- `go test ./...` passes.
- Live-tested on real hardware: deployed and visually confirmed the version now renders on the physical screen.

Closes #84