### PR TITLE
Distinguish missing calibration file from no internet connection

### DIFF
--- a/bin/prod/create-recore-config
+++ b/bin/prod/create-recore-config
@@ -47,12 +47,26 @@ fi
 info "Hardware revision: ${HW_REV}"
 info "Serial number: ${SNR}"
 
-if [[ ! `wget -NS --spider $URL 2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
-  echo "Unable to find the calibration file at the remote location: $URL".
-  exit 2
+# wget's own exit codes distinguish "couldn't reach the server at all"
+# (4 - network failure: no internet, DNS, connection refused, etc.) from
+# "reached the server but it returned an error" (e.g. 8, a 404 - no
+# calibration file for this serial). Report those two cases separately
+# rather than a single generic "unable to find" message either way.
+if wget -q --spider "$URL"; then
+  WGET_STATUS=0
+else
+  WGET_STATUS=$?
 fi
 
-info "Calibration file valid"
+if [ "$WGET_STATUS" -eq 0 ]; then
+  info "Calibration file valid"
+elif [ "$WGET_STATUS" -eq 4 ]; then
+  echo "No internet connection. Setting the serial number requires internet access to download the calibration file."
+  exit 3
+else
+  echo "No calibration file found for serial number ${SNR}. Please check the serial number is correct."
+  exit 2
+fi
 
 DEV=`lsblk -n -o NAME | grep 'mmcblk[0-2]$'`
 DEV_BOOT="/dev/${DEV}boot0"

--- a/reflash/server.go
+++ b/reflash/server.go
@@ -1138,7 +1138,16 @@ func updateConfig(w http.ResponseWriter, r *http.Request) {
 	var data *UpdateConfigCommand = &UpdateConfigCommand{}
 	reqBody, _ := io.ReadAll(r.Body)
 	json.Unmarshal(reqBody, &data)
-	_, _, err := runCommand2("create-recore-config", strconv.Itoa(data.Snr))
+	out, _, err := runCommand2("create-recore-config", strconv.Itoa(data.Snr))
+	// create-recore-config prints a specific, user-facing reason (missing
+	// calibration file vs. no internet connection) before exiting non-zero -
+	// surface that instead of the generic "exit status N" from err.
+	if err != nil {
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if lastLine := lines[len(lines)-1]; lastLine != "" {
+			err = fmt.Errorf("%s", lastLine)
+		}
+	}
 	sendResponse(w, err)
 }
 


### PR DESCRIPTION
## Summary
`create-recore-config` previously reported a missing calibration file and a total network outage identically ("Unable to find the calibration file at the remote location"). These need different user action (check the serial number vs. check the connection), so report them separately - using wget's own exit codes (4 = network failure, vs. a reachable server returning an error) to tell them apart.

Also fixed `updateConfig()` to actually forward the script's specific message to the UI - it previously discarded it entirely and only sent the generic Go `"exit status N"`.

## Testing
- `make test-bats` and `go test ./...` - no regressions.
- Live-tested all three paths through the real UI `/api/update_config` call:
  - Valid serial + internet → `OK`
  - Serial with no matching calibration file → `"No calibration file found for serial number 0499. Please check the serial number is correct."`
  - No internet (simulated via a temporary `/etc/hosts` block on the calibration host) → `"No internet connection. Setting the serial number requires internet access to download the calibration file."`

Closes #83