### PR TITLE
Always unmount the config partition in get-recore-serial-number

### DIFF
--- a/bin/prod/get-recore-serial-number
+++ b/bin/prod/get-recore-serial-number
@@ -5,5 +5,10 @@ set -euo pipefail
 CONFIG_DIR="${REFLASH_CONFIG_DIR:-/mnt/config}"
 
 mount-config
+# A board with no serial number provisioned yet - the exact case this
+# script exists to detect - means serial_number doesn't exist, so cat
+# fails and set -e exits before reaching unmount-config, leaving the
+# mount (and its transient systemd unit) dangling. Make the unmount
+# unconditional instead.
+trap unmount-config EXIT
 cat "$CONFIG_DIR/serial_number"
-unmount-config

--- a/test/bats/getters.bats
+++ b/test/bats/getters.bats
@@ -27,3 +27,15 @@ teardown() { teardown_sandbox; }
   [ "$status" -eq 0 ]
   [ "$output" = "RC-0001-XYZ" ]
 }
+
+@test "get-recore-serial-number: still unmounts when serial_number is missing (#83 fallout)" {
+  export REFLASH_CONFIG_DIR="$SANDBOX/config"
+  mkdir -p "$REFLASH_CONFIG_DIR"
+  # No serial_number file - this is exactly the state a not-yet-provisioned
+  # board is in, i.e. the case this script exists to detect.
+  stub_silent mount-config
+  stub_silent unmount-config
+  run "$PROD_BIN/get-recore-serial-number"
+  [ "$status" -ne 0 ]
+  assert_called_with "unmount-config"
+}


### PR DESCRIPTION
## Summary
`set -euo pipefail` means a missing `serial_number` file (a board that hasn't been provisioned yet - exactly the case this script exists to detect) makes `cat` fail and the script exit before reaching `unmount-config`, leaving the mount - and its transient systemd unit - dangling. That stale mount can then make a later `mount-config` call fail with `Unit mnt-config.mount was already loaded`.

Use a `trap` so the unmount always runs once the mount has succeeded, regardless of how the read afterward turns out.

## Testing
- `make test-bats` - added a regression test asserting `unmount-config` is still called when `serial_number` is missing.
- Live-tested on real hardware: deleted `serial_number`, confirmed the script now fails cleanly (exit 1, no stale `/mnt/config` mount) instead of leaving it mounted, then restored the serial number via `create-recore-config` and confirmed the whole flow (including the UI popup) still works.

Found while testing #83/#85.