### PR TITLE
Fix cancelling a backup showing a generic error instead of cancelled

### DIFF
--- a/reflash/server.go
+++ b/reflash/server.go
@@ -824,9 +824,26 @@ func goBackup() {
 	logInfo(fmt.Sprintf("starting backup of %s at time %s", state.Filename, timeStart.Format("15:04:05")))
 
 	stdout, _, err := runCommand2("backup-emmc", path)
+	mountUsb(MODE_RO)
+
+	// Plain reads/writes of state.State here aren't enough to see
+	// cancelBackup()'s write reliably - without a shared lock, Go's memory
+	// model doesn't guarantee this goroutine observes that write just
+	// because it happened first in wall-clock time. state.Lock() gives the
+	// same guarantee cancelBackup()'s matching lock below relies on.
+	state.Lock()
+	defer state.Unlock()
 	if err != nil {
+		// cancelBackup() kills the backup subprocess to stop it, which makes
+		// runCommand2 return an error here too (exit 137 - SIGKILL) - that's
+		// the expected result of a deliberate cancel, not a real failure.
+		// cancelBackup() sets state to CANCELLED before killing specifically
+		// so this check can tell the two apart instead of overwriting the
+		// cancellation with a generic error.
+		if state.State == CANCELLED {
+			return
+		}
 		logError("Error encountered during backup: \n" + stdout)
-		mountUsb(MODE_RO)
 		state.State = ERROR
 		state.Error = "An error was encountered during backup. Check log for details"
 		return
@@ -834,13 +851,23 @@ func goBackup() {
 
 	duration := time.Since(timeStart)
 	logInfo(fmt.Sprintf("Backup finished in %d minutes and %d seconds", int(duration.Minutes()), int(duration.Seconds())%60))
-	mountUsb(MODE_RO)
 	state.State = FINISHED
 }
 
 func cancelBackup(w http.ResponseWriter, r *http.Request) {
 	duration := time.Since(timeStart)
 	logInfo(fmt.Sprintf("Backup cancelled after %d minutes and %d seconds", int(duration.Minutes()), int(duration.Seconds())%60))
+
+	// Set before killing, not after - goBackup() is blocked waiting on the
+	// subprocess and wakes up as soon as the kill lands, so this needs to
+	// already be visible by then to avoid a race where it sees the kill's
+	// resulting error first and reports it as a generic failure instead.
+	// Locked so that guarantee actually holds under Go's memory model, not
+	// just in wall-clock time - see goBackup().
+	state.Lock()
+	state.State = CANCELLED
+	state.Error = ""
+	state.Unlock()
 
 	cmd := exec.Command("pkill", "-f", "xz", "-9")
 	err := cmd.Run()
@@ -850,7 +877,6 @@ func cancelBackup(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	os.Remove(images_folder + "/" + state.Filename)
-	state.State = CANCELLED
 	sendResponse(w, err)
 }
 


### PR DESCRIPTION
## Summary
`cancelBackup()` kills the backup subprocess to stop it, which makes `goBackup()`'s `runCommand2` call return an error too (exit 137, SIGKILL) - that's the expected result of a deliberate cancel, not a real failure. `goBackup()` had no way to tell the two apart, so every cancelled backup showed "An error was encountered during backup. Check log for details" instead of being recognized as cancelled.

Fixing this needs real synchronization, not just source-order: setting `state.State = CANCELLED` before killing (rather than after) is necessary but not sufficient - without a shared lock, Go's memory model doesn't guarantee `goBackup()`'s goroutine actually observes that write just because it happened first in wall-clock time. Confirmed live: even with just the reordering, a real test still showed a broken mixed state (`CANCELLED` status with the stale error message still attached, from `goBackup()` losing the race). Both sides now use `state.Lock()`/`Unlock()` around the check-and-write, which is what actually guarantees the ordering holds.

## Testing
- `go test ./... -race` - no regressions.
- Live-tested on real hardware via the actual `start_backup`/`cancel_backup` API calls, repeated across multiple runs (this is a timing-sensitive race, so one clean run isn't enough evidence) - cancelling now consistently shows `state: CANCELLED` with no error attached.