### PR TITLE
Hide download options offline, remove Refactor

### DIFF
--- a/bin/prod/has-internet
+++ b/bin/prod/has-internet
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# GitHub is what actually matters here, not internet access in general - the
+# Rebuild/Refactor image downloads and the release list the UI fetches both
+# depend on it specifically, and a generic reachability check could pass
+# while GitHub itself is unreachable.
+if wget -q --spider --timeout=5 --tries=1 https://github.com 2>/dev/null; then
+    echo "true"
+else
+    echo "false"
+fi

--- a/bin/prod/has-internet
+++ b/bin/prod/has-internet
@@ -3,9 +3,9 @@
 set -e
 
 # GitHub is what actually matters here, not internet access in general - the
-# Rebuild/Refactor image downloads and the release list the UI fetches both
-# depend on it specifically, and a generic reachability check could pass
-# while GitHub itself is unreachable.
+# Rebuild image downloads and the release list the UI fetches both depend on
+# it specifically, and a generic reachability check could pass while GitHub
+# itself is unreachable.
 if wget -q --spider --timeout=5 --tries=1 https://github.com 2>/dev/null; then
     echo "true"
 else

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -44,7 +44,7 @@
         <div class="xs1 pa1 align-self-center">
           <w-select
             v-model="selectedMethod"
-            :items="availableMethods"
+            :items="filteredMethods"
             no-unselect
             return-object
           >
@@ -269,6 +269,9 @@ export default {
       { id: 1, label: "Refactor", value: 1, image: "Cloud" },
       { id: 2, label: "File upload", value: 2, image: "File" },
     ],
+    // Optimistic default so the download options aren't shown then
+    // immediately hidden while the check is in flight - see checkInternet().
+    hasInternet: true,
     selectedMethod: 0,
     imageColor: "white",
     files: [],
@@ -280,7 +283,18 @@ export default {
     bytesAvailable: -1,
     sizeWarning: ""
   }),
-  computed: mapGetters(["options", "progress", "flash"]),
+  computed: {
+    ...mapGetters(["options", "progress", "flash"]),
+    // Rebuild/Refactor both download from GitHub via the board itself
+    // (flash-from-url) - without internet that can't work, so hide them and
+    // leave only the local-file paths (upload, magic, install) - #74.
+    filteredMethods() {
+      if (this.hasInternet) {
+        return this.availableMethods;
+      }
+      return this.availableMethods.filter((m) => m.id == 2);
+    },
+  },
   methods: {
     ...mapActions([
       "setProgress",
@@ -800,11 +814,19 @@ export default {
         .then((response) => response.json())
         .then((data) => this.populateRebuildImages(data));
     },
+    async checkInternet() {
+      const response = await axios.get(`/api/has_internet`);
+      this.hasInternet = response.data.result;
+      if (!this.hasInternet && this.selectedMethod.id != 2) {
+        this.selectedMethod = this.availableMethods[2];
+      }
+    },
   },
   created() {
     this.selectedMethod = this.availableMethods[0];
     this.getGithubImages();
     this.getInfo();
+    this.checkInternet();
     this.checkOnLoadProgress();
   },
 };

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -120,15 +120,6 @@
             placeholder="Please select one"
           >
           </w-select>
-          <w-select
-            v-if="selectedMethod.id == 1"
-            v-model="selectedRefactorImage"
-            return-object
-            :items="refactorImages"
-            item-label-key="name"
-            placeholder="Please select one"
-          >
-          </w-select>
           <w-input
             v-if="selectedMethod.id == 2"
             type="file"
@@ -201,7 +192,7 @@
         <TheWifiSetup
           :open="openWifi"
           ref="TheWifiSetup"
-          @close="openWifi = false"
+          @close="openWifi = false; this.checkInternet()"
         />
       </w-flex>
     </w-card>
@@ -249,12 +240,10 @@ export default {
     isInstalling: false,
     installProgress: 0,
     selectedGithubImage: undefined,
-    selectedRefactorImage: undefined,
     selectedRebuildImage: undefined,
     selectedUploadImage: [],
     selectedLocalImage: undefined,
     githubImages: [],
-    refactorImages: [],
     rebuildImages: [],
     localImages: [],
     uploadError: false,
@@ -266,7 +255,6 @@ export default {
     openWifi: false,
     availableMethods: [
       { id: 0, label: "Rebuild", value: 0, image: "Cloud" },
-      { id: 1, label: "Refactor", value: 1, image: "Cloud" },
       { id: 2, label: "File upload", value: 2, image: "File" },
     ],
     // Optimistic default so the download options aren't shown then
@@ -285,9 +273,9 @@ export default {
   }),
   computed: {
     ...mapGetters(["options", "progress", "flash"]),
-    // Rebuild/Refactor both download from GitHub via the board itself
-    // (flash-from-url) - without internet that can't work, so hide them and
-    // leave only the local-file paths (upload, magic, install) - #74.
+    // Rebuild downloads from GitHub via the board itself (flash-from-url) -
+    // without internet that can't work, so hide it and leave only the
+    // local-file paths (upload, magic, install) - #74.
     filteredMethods() {
       if (this.hasInternet) {
         return this.availableMethods;
@@ -311,8 +299,6 @@ export default {
     },
     computeTransferButtonText() {
       if (this.selectedMethod.id == 0)
-        return this.state == "DOWNLOADING" ? "Cancel" : "Download";
-      if (this.selectedMethod.id == 1)
         return this.state == "DOWNLOADING" ? "Cancel" : "Download";
       if (this.selectedMethod.id == 2)
         return this.state == "UPLOADING" ? "Cancel" : "Upload";
@@ -347,8 +333,6 @@ export default {
     isMagicButtonVisible() {
       if (!this.options.magicmode) return false;
       if (this.selectedMethod.id == 0 && this.selectedRebuildImage) return true;
-      if (this.selectedMethod.id == 1 && this.selectedRefactorImage)
-        return true;
       if (this.selectedMethod.id == 2 && this.selectedUploadImage.file)
         return true;
       return false;
@@ -356,7 +340,6 @@ export default {
     isTransferButtonVisible() {
       if (this.options.magicmode) return false;
       if (this.selectedMethod.id == 0) return this.selectedRebuildImage;
-      if (this.selectedMethod.id == 1) return this.selectedRefactorImage;
       if (this.selectedMethod.id == 2) return this.selectedUploadImage.file;
       return "";
     },
@@ -374,13 +357,6 @@ export default {
         this.selectedGithubImage &&
         this.bytesAvailable > 0 &&
         this.bytesAvailable < this.selectedGithubImage.size
-      ) {
-        return "Not enough free space on USB";
-      } else if (
-        this.selectedMethod.id == 1 &&
-        this.selectedUploadImage.file &&
-        this.bytesAvailable > 0 &&
-        this.bytesAvailable < this.selectedUploadImage.size
       ) {
         return "Not enough free space on USB";
       } else {
@@ -573,9 +549,6 @@ export default {
       if (this.selectedMethod.id == 0) {
         this.selectedGithubImage = this.selectedRebuildImage;
         this.startMagic();
-      } else if (this.selectedMethod.id == 1) {
-        this.selectedGithubImage = this.selectedRefactorImage;
-        this.startMagic();
       } else if (this.selectedMethod.id == 2) {
         this.selectedGithubImage = this.selectedLocalImage;
         this.startMagicUpload();
@@ -616,7 +589,7 @@ export default {
         }
         // This method is called on page load. If a refresh happens during upload, we can not continue.
       } else if (data.state == "UPLOADING" || data.state == "UPLOADING_MAGIC") {
-        this.selectedMethod = this.availableMethods[2];
+        this.selectedMethod = this.availableMethods.find((m) => m.id == 2);
       }
       this.previousState = this.state;
       this.checkProgress();
@@ -651,7 +624,6 @@ export default {
           this.getInfo();
         } else if (this.previousState == "DOWNLOADING") {
           this.selectedRebuildImage = null;
-          this.selectedRefactorImage = null;
           await this.getInfo();
           this.selectedLocalImage = data.filename;
         } else if (this.previousState == "UPLOADING") {
@@ -660,7 +632,6 @@ export default {
           this.selectedLocalImage = data.filename;
         } else if (this.previousState == "MAGIC") {
           this.selectedRebuildImage = null;
-          this.selectedRefactorImage = null;
           await axios.get(`/api/run_install_finished_commands`);
           this.installFinished = true;
         } else if (this.previousState == "UPLOADING_MAGIC") {
@@ -681,9 +652,6 @@ export default {
     onTransferButtonClick() {
       if (this.selectedMethod.id == 0) {
         this.selectedGithubImage = this.selectedRebuildImage;
-        this.downloadSelected();
-      } else if (this.selectedMethod.id == 1) {
-        this.selectedGithubImage = this.selectedRefactorImage;
         this.downloadSelected();
       } else if (this.selectedMethod.id == 2) {
         this.uploadSelected();
@@ -768,20 +736,6 @@ export default {
         }
       }
     },
-    populateRefactorImages(releases) {
-      for (let release of releases) {
-        for (let asset of release.assets) {
-          if (asset.name.includes("Refactor-recore")) {
-            this.refactorImages.push({
-              name: asset.name,
-              id: asset.id,
-              url: asset.browser_download_url,
-              size: asset.size,
-            });
-          }
-        }
-      }
-    },
     populateRebuildImages(releases) {
       for (let release of releases) {
         for (let asset of release.assets) {
@@ -807,9 +761,10 @@ export default {
       this.openSerialNumber = (this.serial_number == "");
     },
     async getGithubImages() {
-      fetch("https://api.github.com/repos/intelligent-agent/Refactor/releases")
-        .then((response) => response.json())
-        .then((data) => this.populateRefactorImages(data));
+      // Reset first - this can now be called again (see checkInternet())
+      // after already having been called once, and populateRebuildImages
+      // appends rather than replaces.
+      this.rebuildImages = [];
       fetch("https://api.github.com/repos/intelligent-agent/Rebuild/releases")
         .then((response) => response.json())
         .then((data) => this.populateRebuildImages(data));
@@ -817,13 +772,18 @@ export default {
     async checkInternet() {
       const response = await axios.get(`/api/has_internet`);
       this.hasInternet = response.data.result;
-      if (!this.hasInternet && this.selectedMethod.id != 2) {
-        this.selectedMethod = this.availableMethods[2];
+      if (this.hasInternet) {
+        // Refetch in case the initial page-load fetch happened before
+        // internet was available (e.g. connected via the WiFi setup
+        // window), which would otherwise leave rebuildImages empty.
+        this.getGithubImages();
+      } else if (this.selectedMethod.id != 2) {
+        this.selectedMethod = this.availableMethods.find((m) => m.id == 2);
       }
     },
   },
   created() {
-    this.selectedMethod = this.availableMethods[0];
+    this.selectedMethod = this.availableMethods.find((m) => m.id == 0);
     this.getGithubImages();
     this.getInfo();
     this.checkInternet();

--- a/reflash/server.go
+++ b/reflash/server.go
@@ -241,6 +241,7 @@ func ServerInit() {
 	http.HandleFunc("/api/reboot_board", rebootBoard)
 	http.HandleFunc("/api/shutdown_board", shutdownBoard)
 	http.HandleFunc("/api/is_usb_present", isUsbPresent)
+	http.HandleFunc("/api/has_internet", hasInternet)
 	http.HandleFunc("/api/start_backup", startBackup)
 	http.HandleFunc("/api/cancel_backup", cancelBackup)
 	http.HandleFunc("/api/start_magic", startMagic)
@@ -1202,6 +1203,14 @@ func setSshEnabled(is_enabled bool) error {
 
 func isUsbPresent(w http.ResponseWriter, r *http.Request) {
 	result := runCommandReturnBool("is-usb-present")
+	var response *BinaryCommandResult = &BinaryCommandResult{
+		Result: result,
+	}
+	json.NewEncoder(w).Encode(response)
+}
+
+func hasInternet(w http.ResponseWriter, r *http.Request) {
+	result := runCommandReturnBool("has-internet")
 	var response *BinaryCommandResult = &BinaryCommandResult{
 		Result: result,
 	}


### PR DESCRIPTION
## Summary
- Adds a `has-internet` script + `/api/has_internet` endpoint checking GitHub reachability specifically, and hides the GitHub-download methods (Rebuild) in the UI when there's no internet - closes #74
- `checkInternet()` runs on page load and when the WiFi setup window closes
- Removes the "Refactor" download method entirely (dropdown entry, data, and all `id==1` branches) since it's no longer offered
- Fixes two bugs found live-testing on the board in AP mode:
  - `getGithubImages()` only ran once in `created()` and never retried, so `rebuildImages` stayed empty forever if the page loaded before internet was available - now retriggered from `checkInternet()` once connectivity is confirmed
  - Removing Refactor shifted `availableMethods`, so hardcoded `availableMethods[2]` lookups went out of bounds and crashed the app with no internet - switched to id-based lookups

## Test plan
- [x] Live-tested on real hardware: switched board to AP mode via serial console, confirmed dropdown no longer shows Refactor and the app no longer crashes with no internet
- [x] Confirmed image list repopulates after connecting to WiFi via the setup window
- [x] `make build-vue` succeeds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)