### PR TITLE
Fix log stream dying silently across WiFi mode switches

### DIFF
--- a/client/src/components/TheLogger.vue
+++ b/client/src/components/TheLogger.vue
@@ -25,7 +25,9 @@ export default {
     open: Boolean
   },
   data: () => ({
-    log: []
+    log: [],
+    evtSource: null,
+    watchdog: null
   }),
   methods: {
     replaceWithBr() {
@@ -36,13 +38,48 @@ export default {
       const response = await axios.put(`/api/clear_log`)
       if(response.data.status != 0)
         this.$waveui.notify("Unable to clear log", "error", 0);
+    },
+    connectLogStream() {
+      const evtSource = new EventSource(`/api/stream_log`);
+      evtSource.onmessage = (event) => {
+        this.log.push(event.data);
+        this.resetWatchdog();
+      };
+      // The server sends one of these every 15s (see streamLog in
+      // server.go) purely so the watchdog below has something to reset
+      // on even when there's no real log activity.
+      evtSource.addEventListener('heartbeat', () => {
+        this.resetWatchdog();
+      });
+      // The board's WiFi interface disappears and reappears when
+      // switching between AP/hotspot and station mode (#95). Confirmed
+      // live: that kills the connection completely silently on both
+      // ends - no error, no data, nothing - so onerror is not enough on
+      // its own; the watchdog below is what actually catches this case.
+      evtSource.onerror = () => {
+        this.reconnect();
+      };
+      this.evtSource = evtSource;
+      this.resetWatchdog();
+    },
+    resetWatchdog() {
+      clearTimeout(this.watchdog);
+      // Twice the server's heartbeat interval, so one missed beat isn't
+      // treated as a dead connection.
+      this.watchdog = setTimeout(() => this.reconnect(), 30000);
+    },
+    reconnect() {
+      clearTimeout(this.watchdog);
+      if (this.evtSource) this.evtSource.close();
+      setTimeout(() => this.connectLogStream(), 3000);
     }
   },
   created() {
-    const evtSource = new EventSource(`/api/stream_log`);
-    evtSource.onmessage = (event) => {
-      this.log.push(event.data);
-    };
+    this.connectLogStream();
+  },
+  beforeUnmount() {
+    clearTimeout(this.watchdog);
+    if (this.evtSource) this.evtSource.close();
   }
 }
 

--- a/reflash/server.go
+++ b/reflash/server.go
@@ -492,9 +492,37 @@ func streamLog(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	for line := range t.Lines {
-		fmt.Fprint(w, fmt.Sprintf("data: %s\n\n", line.Text))
-		flusher.Flush()
+	// Without watching the request context, this handler (and its tail
+	// follower) never returns once the client goes away - e.g. every
+	// time the log viewer's EventSource drops during a WiFi mode switch
+	// (#95) - leaking one goroutine per dropped connection forever.
+	defer t.Stop()
+
+	// Confirmed live (#95): when the board's WiFi interface disappears
+	// mid-stream (switching AP/station mode), the connection just goes
+	// silent on both ends - no RST, no read error, nothing - so neither
+	// side's error handling ever fires and the client waits forever. A
+	// periodic heartbeat lets the client notice the silence and
+	// reconnect on its own instead.
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, "event: heartbeat\ndata: \n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		case line, ok := <-t.Lines:
+			if !ok {
+				return
+			}
+			fmt.Fprintf(w, "data: %s\n\n", line.Text)
+			flusher.Flush()
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- \`streamLog()\` never checked for client disconnection - the handler (and its tail follower) ran forever even after the client was gone, leaking one goroutine per dropped connection
- Reproduced #95 directly: when the board's WiFi interface disappears mid-stream (AP/station switch), the connection goes completely silent on both ends - no RST, no read error. Neither side's error handling fires, so the client waits forever
- \`streamLog()\` now watches the request context and returns/cleans up on disconnect, and sends a 15s heartbeat event
- The client watches for the heartbeat with a 30s watchdog and reconnects itself if none arrives, instead of relying on \`onerror\` which never fires in this scenario

Closes #95

## Test plan
- [x] Live-tested on real hardware: opened a raw stream connection, switched the board through an AP/station round-trip, confirmed via \`ss\` that the server-side connection cleaned up with no lingering CLOSE_WAIT sockets and no leaked goroutines
- [x] Confirmed the heartbeat event is actually emitted every 15s
- [x] Confirmed a fresh connection works cleanly immediately after the round-trip
- [x] User confirmed the log viewer keeps working across a live WiFi mode switch in the browser
- [x] `go test ./...` and `bats test/bats` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)