### PR TITLE
Fix expand-usb first-boot race that broke SSH on RC3

### DIFF
--- a/bin/prod/expand-usb
+++ b/bin/prod/expand-usb
@@ -16,15 +16,23 @@ fi
 
 info "Creating partition on unused space"
 # fdisk's own in-place re-read of the table can fail with "Device or
-# resource busy" even though the write itself succeeded (seen live on a
-# fresh USB drive) - the kernel picks up the new partition via udev
-# shortly after regardless, so don't treat that as fatal; wait for the
-# device node to actually appear instead of trusting fdisk's exit code.
+# resource busy" even though the write itself succeeded - a full
+# re-read (BLKRRPART) needs every partition on the disk free, and
+# partition 1 is normally still in use at this point in boot. Confirmed
+# live (twice - once in isolation, once on a genuinely fresh first boot
+# under real system load): the busy re-read is not a fluke, and how
+# long the kernel takes to pick up the new partition on its own varies
+# a lot with system load, so a short fixed wait is not reliable.
 printf "n\n\n\n\nw\n" | fdisk /dev/sda || true
 
 info "Waiting for /dev/sda2 to appear"
-for i in $(seq 1 10); do
+for i in $(seq 1 60); do
     [ -b /dev/sda2 ] && break
+    # partx adds a single new partition via BLKPG instead of
+    # invalidating the whole table, so it isn't blocked by partition 1
+    # being busy the way fdisk's own re-read (and blockdev --rereadpt)
+    # are - nudge it along instead of only waiting passively.
+    partx -a -n 2 /dev/sda >/dev/null 2>&1 || true
     sleep 1
 done
 


### PR DESCRIPTION
## Summary
RC3 shipped with a real regression: \`ssh-keygen-boot.service\` fails on a genuinely fresh boot because the 10s wait for \`/dev/sda2\` to appear (added while investigating #90) isn't long enough under actual first-boot system load, only verified in isolation with the system otherwise idle. When it times out, no SSH host keys ever get generated and sshd is permanently unable to start (5 failed restarts, then gives up). \`reflash.service\` itself recovers on its own via its own internal retry loop, so the board looks like it's working from the touchscreen/web UI, but SSH access is broken.

- Bumped the wait to 60s
- Added an active \`partx -a -n 2\` nudge each iteration - fdisk's own re-read (and \`blockdev --rereadpt\`) fail with "Device or resource busy" since a full re-read needs every partition free, including partition 1 which is normally still in use at this point in boot; \`partx\` adds just the new partition via BLKPG instead, which isn't blocked by that

## Test plan
- [x] Reproduced live: wiped partition 2 back to a genuinely fresh state on real hardware, rebooted, confirmed the old code's failure mode
- [x] Verified the fix live: same wipe + reboot, confirmed \`ssh-keygen-boot.service\`, \`ssh.service\`, and \`reflash.service\` all came up successfully - partition took ~15-20s to appear under real load, past the old 10s window, inside the new one
- [x] `go test ./...` and `bats test/bats` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)