### PR TITLE
Fix progress polling silently dying on a transient timeout

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -573,81 +573,100 @@ export default {
       }
     },
     async checkOnLoadProgress() {
-      const response = await axios.get(`/api/get_progress`);
-      let data = response.data;
-      this.state = data.state;
-      if (data.state == "MAGIC") {
-        this.selectedGithubImage = this.getGithubImageFromName(data.filename);
-      } else if (data.state == "DOWNLOADING") {
-        this.selectedGithubImage = this.getGithubImageFromName(data.filename);
-      } else if (data.state == "INSTALLING") {
-        this.selectedLocalImage = data.filename;
-      } else if (data.state == "BACKUPING") {
-        if (this.flash.selectedMethod != 1) {
-          this.$refs.flashSelector.setSelection(1);
-          this.backupFile = data.filename;
+      // If this one-shot call fails (see checkProgress() below for why
+      // that's a real possibility), checkProgress() never even gets
+      // called, and the polling loop that's supposed to watch an
+      // in-progress operation never starts in the first place.
+      try {
+        const response = await axios.get(`/api/get_progress`);
+        let data = response.data;
+        this.state = data.state;
+        if (data.state == "MAGIC") {
+          this.selectedGithubImage = this.getGithubImageFromName(data.filename);
+        } else if (data.state == "DOWNLOADING") {
+          this.selectedGithubImage = this.getGithubImageFromName(data.filename);
+        } else if (data.state == "INSTALLING") {
+          this.selectedLocalImage = data.filename;
+        } else if (data.state == "BACKUPING") {
+          if (this.flash.selectedMethod != 1) {
+            this.$refs.flashSelector.setSelection(1);
+            this.backupFile = data.filename;
+          }
+          // This method is called on page load. If a refresh happens during upload, we can not continue.
+        } else if (data.state == "UPLOADING" || data.state == "UPLOADING_MAGIC") {
+          this.selectedMethod = this.availableMethods.find((m) => m.id == 2);
         }
-        // This method is called on page load. If a refresh happens during upload, we can not continue.
-      } else if (data.state == "UPLOADING" || data.state == "UPLOADING_MAGIC") {
-        this.selectedMethod = this.availableMethods.find((m) => m.id == 2);
+        this.previousState = this.state;
+      } catch (err) {
+        console.log("checkOnLoadProgress failed, starting polling anyway: " + err);
       }
-      this.previousState = this.state;
       this.checkProgress();
     },
     async checkProgress() {
-      const response = await axios.get(`/api/get_progress`);
-      let data = response.data;
-      this.state = data.state;
-      if (
-        [
-          "DOWNLOADING",
-          "UPLOADING",
-          "INSTALLING",
-          "BACKUPING",
-          "MAGIC",
-          "UPLOADING_MAGIC",
-        ].includes(this.state)
-      ) {
-        this.setProgress({ progress: data.progress });
-        this.setBandwidth({ bandwidth: data.bandwidth });
-        this.setTimeStarted({ time: data.start_time });
-        this.$refs.installprogressbar.update();
-        this.$refs.magicprogressbar.update();
-        this.$refs.transferprogressbar.update();
-      } else if (data.state == "FINISHED") {
-        if (this.previousState == "INSTALLING") {
-          this.selectedLocalImage = null;
-          await axios.get(`/api/run_install_finished_commands`);
-          this.installFinished = true;
-        } else if (this.previousState == "BACKUPING") {
-          this.backupFile = "";
+      // A timeout here (the server can legitimately take a while to
+      // respond while it's busy with heavy eMMC I/O mid-flash) used to
+      // throw out of this function entirely, skipping the
+      // setTimeout(...) below and silently killing the polling loop for
+      // good - the flash kept running server-side, but the UI stopped
+      // watching it and just looked frozen. Retry instead of dying.
+      try {
+        const response = await axios.get(`/api/get_progress`);
+        let data = response.data;
+        this.state = data.state;
+        if (
+          [
+            "DOWNLOADING",
+            "UPLOADING",
+            "INSTALLING",
+            "BACKUPING",
+            "MAGIC",
+            "UPLOADING_MAGIC",
+          ].includes(this.state)
+        ) {
+          this.setProgress({ progress: data.progress });
+          this.setBandwidth({ bandwidth: data.bandwidth });
+          this.setTimeStarted({ time: data.start_time });
+          this.$refs.installprogressbar.update();
+          this.$refs.magicprogressbar.update();
+          this.$refs.transferprogressbar.update();
+        } else if (data.state == "FINISHED") {
+          if (this.previousState == "INSTALLING") {
+            this.selectedLocalImage = null;
+            await axios.get(`/api/run_install_finished_commands`);
+            this.installFinished = true;
+          } else if (this.previousState == "BACKUPING") {
+            this.backupFile = "";
+            this.getInfo();
+          } else if (this.previousState == "DOWNLOADING") {
+            this.selectedRebuildImage = null;
+            await this.getInfo();
+            this.selectedLocalImage = data.filename;
+          } else if (this.previousState == "UPLOADING") {
+            this.selectedUploadImage = [];
+            await this.getInfo();
+            this.selectedLocalImage = data.filename;
+          } else if (this.previousState == "MAGIC") {
+            this.selectedRebuildImage = null;
+            await axios.get(`/api/run_install_finished_commands`);
+            this.installFinished = true;
+          } else if (this.previousState == "UPLOADING_MAGIC") {
+            this.selectedUploadImage = [];
+            await axios.get(`/api/run_install_finished_commands`);
+            this.installFinished = true;
+          }
+        } else if (data.state == "CANCELLED") {
+          this.selectedGithubImage = null;
           this.getInfo();
-        } else if (this.previousState == "DOWNLOADING") {
-          this.selectedRebuildImage = null;
-          await this.getInfo();
-          this.selectedLocalImage = data.filename;
-        } else if (this.previousState == "UPLOADING") {
-          this.selectedUploadImage = [];
-          await this.getInfo();
-          this.selectedLocalImage = data.filename;
-        } else if (this.previousState == "MAGIC") {
-          this.selectedRebuildImage = null;
-          await axios.get(`/api/run_install_finished_commands`);
-          this.installFinished = true;
-        } else if (this.previousState == "UPLOADING_MAGIC") {
-          this.selectedUploadImage = [];
-          await axios.get(`/api/run_install_finished_commands`);
-          this.installFinished = true;
+        } else if (data.state == "ERROR") {
+          this.$waveui.notify(data.error, "error", 0);
         }
-      } else if (data.state == "CANCELLED") {
-        this.selectedGithubImage = null;
-        this.getInfo();
-      } else if (data.state == "ERROR") {
-        this.$waveui.notify(data.error, "error", 0);
-      }
 
-      this.previousState = this.state;
-      if (data.state != "IDLE") setTimeout(this.checkProgress, 1000);
+        this.previousState = this.state;
+        if (data.state != "IDLE") setTimeout(this.checkProgress, 1000);
+      } catch (err) {
+        console.log("get_progress failed, retrying: " + err);
+        setTimeout(this.checkProgress, 1000);
+      }
     },
     onTransferButtonClick() {
       if (this.selectedMethod.id == 0) {

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -15,7 +15,18 @@ import 'wave-ui/dist/wave-ui.css'
 // once starves every other request, including ones with their own
 // explicit timeout, since they can't get a socket to run on at all. A
 // global default bounds every request that doesn't set its own.
-axios.defaults.timeout = 10000
+//
+// 10s turned out too tight: get_progress can legitimately take longer
+// than that while the server is busy with heavy eMMC I/O mid-flash, and
+// checkProgress() in App.vue had no error handling, so that "safety
+// net" timeout firing was itself silently killing the progress-polling
+// loop - the flash kept running server-side, but the UI stopped
+// watching it entirely and looked frozen (confirmed live: a magic flash
+// completed successfully in the background 5+ minutes after the UI
+// had already gone quiet). checkProgress() now retries on failure
+// instead of dying, so this is just about reducing how often that
+// retry path needs to trigger during legitimate slow responses.
+axios.defaults.timeout = 30000
 
 const app = createApp(App)
 app.use(store)


### PR DESCRIPTION
## Summary
- `checkProgress()` had no error handling around its `axios.get` call - a timeout (made more likely by the global 10s default added for #90/#95, since the server can legitimately take longer than that while busy with heavy eMMC I/O mid-flash) threw out of the function entirely, skipping the `setTimeout(...)` that reschedules the next poll and silently killing the polling loop for good
- Confirmed live: a magic flash completed successfully server-side (5m34s) minutes after the UI had already gone silent and looked frozen - the flash was never actually broken, the UI just stopped watching it
- `checkProgress()`/`checkOnLoadProgress()` now retry on failure instead of dying
- Bumped the global axios timeout from 10s to 30s, since the retry logic is now the real safety net

## Test plan
- [x] Live-tested on real hardware: reproduced the exact failure (magic flash completing successfully while the UI stayed frozen), then confirmed the fix keeps the UI updating throughout
- [x] `make test-vue`, `bats test/bats`, `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)